### PR TITLE
allow connecting to self-hosted gitlab without https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `get_client` method and `url` field to `GitLabCredentials` - [#9](https://github.com/PrefectHQ/prefect-gitlab/pull/9)
+- allow `http` connection to self-hosted gitlab without https - [#14](https://github.com/PrefectHQ/prefect-gitlab/pull/14)
 
 ### Changed
 

--- a/prefect_gitlab/repositories.py
+++ b/prefect_gitlab/repositories.py
@@ -94,7 +94,7 @@ class GitLabRepository(ReadableDeploymentStorage):
         private repositories are used.
         """
         if v is not None:
-            if urllib.parse.urlparse(values["repository"]).scheme in ["https", "http"]:
+            if urllib.parse.urlparse(values["repository"]).scheme not in ["https", "http"]:
                 raise InvalidRepositoryURLError(
                     (
                         "Credentials can only be used with GitLab repositories "

--- a/prefect_gitlab/repositories.py
+++ b/prefect_gitlab/repositories.py
@@ -94,7 +94,10 @@ class GitLabRepository(ReadableDeploymentStorage):
         private repositories are used.
         """
         if v is not None:
-            if urllib.parse.urlparse(values["repository"]).scheme not in ["https", "http"]:
+            if urllib.parse.urlparse(values["repository"]).scheme not in [
+                "https",
+                "http",
+            ]:
                 raise InvalidRepositoryURLError(
                     (
                         "Credentials can only be used with GitLab repositories "

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -142,7 +142,7 @@ class TestGitLab:
         assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
     async def test_ssh_fails_with_credential(self, monkeypatch):
-        """Ensure that credentials cannot be passed in if the URL is not in the HTTPS
+        """Ensure that credentials cannot be passed in if the URL is not in the HTTPS/HTTP
         format.
         """
 
@@ -154,10 +154,10 @@ class TestGitLab:
         credential = "XYZ"
         error_msg = (
             "Credentials can only be used with GitLab repositories "
-            "using the 'HTTPS' format. You must either remove the "
+            "using the 'HTTPS'/'HTTP' format. You must either remove the "
             "credential if you wish to use the 'SSH' format and are not "
             "using a private repository, or you must change the repository "
-            "URL to the 'HTTPS' format."
+            "URL to the 'HTTPS'/'HTTP' format."
         )
         with pytest.raises(InvalidRepositoryURLError, match=error_msg):
             GitLabRepository(


### PR DESCRIPTION
<!-- Overview -->

Closes  #5 

The changes allow connection to self-hosted gitlab that with no https 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/prefecthq/prefect-gitlab/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/prefecthq/prefect-gitlab/blob/main/CHANGELOG.md)
