### PR TITLE
Add `GitLabCredentials` placeholder text for `token` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Add placeholder text to `GitLabCredentials` token field in UI - [#23](
+    https://github.com/PrefectHQ/prefect-gitlab/pull/23/)
 
 ### Changed
 

--- a/prefect_gitlab/credentials.py
+++ b/prefect_gitlab/credentials.py
@@ -32,6 +32,7 @@ class GitLabCredentials(Block):
         name="Personal Access Token",
         default=None,
         description="A GitLab Personal Access Token with read_repository scope.",
+        example="oauth2:my-token",
     )
     url: str = Field(
         default=None, title="URL", description="URL to self-hosted GitLab instances."


### PR DESCRIPTION
Part of closing https://github.com/PrefectHQ/prefect/issues/10468

<img width="499" alt="Screenshot 2023-08-31 at 3 36 56 PM" src="https://github.com/PrefectHQ/prefect-gitlab/assets/42048900/9bf2628b-f25a-4d30-a1f4-1e550b6157a1">


### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/prefecthq/prefect-gitlab/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/prefecthq/prefect-gitlab/blob/main/CHANGELOG.md)
