### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_gitlab/credentials.py
+++ b/prefect_gitlab/credentials.py
@@ -2,7 +2,12 @@
 
 from gitlab import Gitlab
 from prefect.blocks.core import Block
-from pydantic import Field, HttpUrl, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, HttpUrl, SecretStr
+else:
+    from pydantic import Field, HttpUrl, SecretStr
 
 
 class GitLabCredentials(Block):

--- a/prefect_gitlab/repositories.py
+++ b/prefect_gitlab/repositories.py
@@ -51,7 +51,12 @@ from prefect.exceptions import InvalidRepositoryURLError
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.processutils import run_process
-from pydantic import Field, HttpUrl, validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, HttpUrl, validator
+else:
+    from pydantic import Field, HttpUrl, validator
 
 from prefect_gitlab.credentials import GitLabCredentials
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -6,7 +6,12 @@ from typing import Set, Tuple
 import pytest
 from prefect.exceptions import InvalidRepositoryURLError
 from prefect.testing.utilities import AsyncMock
-from pydantic import SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import SecretStr
+else:
+    from pydantic import SecretStr
 
 import prefect_gitlab
 from prefect_gitlab.credentials import GitLabCredentials


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.