### PR TITLE
Add retries and backoff to get_directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 prefect>=2.13.5
 python-gitlab>=3.12.0
+tenacity>=8.2.3


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

### Overview

This pull request introduces an exponential backoff strategy for the `get_directory` method in the `GitLabRepository` class. The retry mechanism is enhanced by increasing the delay between retries exponentially, which is more effective for handling scenarios like temporary network issues.

Closes #33 

### Example

```python
# Example usage of get_directory with exponential backoff
gitlab_repo = GitLabRepository(repository="https://gitlab.com/example/repo.git")
await gitlab_repo.get_directory(from_path="src", local_path="dest", max_retries=3, retry_delay=5, backoff_factor=2)
```

### Screenshots

<!-- 
Any relevant screenshots:
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/prefecthq/prefect-gitlab/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` to view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/prefecthq/prefect-gitlab/blob/main/CHANGELOG.md)